### PR TITLE
Fix Flask compatibility by pinning Werkzeug to 2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python cache files
+__pycache__/
+*.py[cod]
+*$py.class
+*.cpython-*
+
+# Virtual environment (if used)
+venv/
+.env/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.3
+Werkzeug==2.0.3
 requests==2.26.0
 dataclasses-json==0.5.7


### PR DESCRIPTION
## Summary
Fixes application crash on startup caused by incompatibility between Flask 2.0.3 and newer Werkzeug versions.

## Changes
- Pin Werkzeug to version 2.0.3 in requirements.txt

## Reason
Flask 2.0.3 depends on `url_quote`, which was removed in Werkzeug >= 2.1.

## Suggested Scope
Added a .gitignore to prevent Python cache files (e.g., __pycache__, *.pyc) from being accidentally committed by contributors.

Closes #4
